### PR TITLE
Fixed a bug where pump does not have enough time to set bolus or temp…

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronicESP/MedtronicPump.java
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/pump/medtronicESP/MedtronicPump.java
@@ -84,7 +84,13 @@ public class MedtronicPump {
     public static final int connectionAttemptThreshold = 10; // Connection attempts before altering user.
     public static final int commandRetryThreshold = 10; // Number of command retries before alerting user.
     public static final long timeIntervalBetweenCommands = 500; // Time in milliseconds before retrying last command.
-    public static final long bolusAndTempSetDelay = 300000; // Time in milliseconds before retrying last command.
+
+    public static final double pumpBolusStep = 0.05;
+    public static final double pumpBasalStep = 0.025;
+    public static final int pumpDurationStep = 30;
+    public static final int pumpButtonPressTime = 50; // Press time in milliseconds.
+    public static final int pumpButtonPressDleay = 200; // Time between button press in milliseconds.
+    public static final long delayError = 10000; // Additional time to make sure temp or bolus is set.
 
     // Preference defined variables
     public int wakeInterval = 1; // Wake interval


### PR DESCRIPTION
… before AndroidAPS expects an answer.

Reworked alarms so that on device not responding to commands and premature disconnect, another connection attempts will be made, counting towards a total of 10 connection attempts before an error is thrown.